### PR TITLE
Wait for the queue to be quiesced for the cool-down period

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/XciD/k8s-rmq-autoscaler
 
+go 1.14
+
 require (
 	4d63.com/gochecknoglobals v0.0.0-20190118042838-abbdf6ec0afb // indirect
 	4d63.com/gochecknoinits v0.0.0-20180528051558-14d5915061e5 // indirect

--- a/rmq.go
+++ b/rmq.go
@@ -13,9 +13,23 @@ type rmq struct {
 	Password string
 }
 
+type queueStatSample struct {
+	Timestamp int32 `json:"timestamp"`
+	Sample    int32 `json:"sample"`
+}
+
+type queueStatDetails struct {
+	Samples []queueStatSample `json:"samples"`
+}
+
+type queueMessageStats struct {
+	PublishDetails queueStatDetails `json:"publish_details"`
+}
+
 type queueResponse struct {
-	Consumers int32 `json:"consumers"`
-	Messages  int32 `json:"messages"`
+	Consumers    int32             `json:"consumers"`
+	Messages     int32             `json:"messages"`
+	MessageStats queueMessageStats `json:"message_stats"`
 }
 
 func newRmq(rmqURL string, rmqUser string, rmqPassword string) (*rmq, error) {
@@ -31,26 +45,35 @@ func newRmq(rmqURL string, rmqUser string, rmqPassword string) (*rmq, error) {
 	}, nil
 }
 
-func (rmq *rmq) getQueueInformation(queue string, vhost string) (int32, int32, error) {
+func (rmq *rmq) getQueueInformation(queue string, vhost string, cooldown int32) (int32, int32, int32, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/queues/%s/%s", rmq.URL, vhost, queue), nil)
+	var statsAge int32
+	statsAge = max(cooldown, 1)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/queues/%s/%s?columns=messages,consumers,message_stats.publish_details&msg_rates_age=%d&msg_rates_incr=%d", rmq.URL, vhost, queue, statsAge, statsAge), nil)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 	req.SetBasicAuth(rmq.User, rmq.Password)
 	resp, err := client.Do(req)
 
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 
 	if resp.StatusCode != 200 {
-		return 0, 0, errors.New(resp.Status)
+		return 0, 0, 0, errors.New(resp.Status)
 	}
 
 	defer resp.Body.Close()
 	var data queueResponse
 	json.NewDecoder(resp.Body).Decode(&data)
 
-	return data.Consumers, data.Messages, nil
+	var messagesPublished int32
+	if cooldown == 0 {
+		messagesPublished = 0
+	} else {
+		messagesPublished = data.MessageStats.PublishDetails.Samples[0].Sample - data.MessageStats.PublishDetails.Samples[1].Sample
+	}
+
+	return data.Consumers, data.Messages, messagesPublished, nil
 }


### PR DESCRIPTION
When safe-unscale is enabled, the application will not be scaled in until the queue is 0.

This will add another check to see if any messages have been published in the cool-down period. This is to account for sampling error.

The pod might still get terminated with pending messages:
- A message is published in the time between checking the queue and the actual scale-in taking effect
- RMQ gave unreliable message stats. This seems at least somewhat common.
- Hardware failures, spot instance terminate, etc.